### PR TITLE
Add GPU model support policy

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -17,11 +17,11 @@ check_language(CUDA)
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
 # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 	set(CMAKE_CUDA_ARCHITECTURES
-		60 # P100
 		70 # V100
-		75 # T4
-		80 # A100
-		# 89 # RTX 40
+		75 # RTX 20, T4
+		80 # A100, A800
+		86 # RTX 30
+		89 # RTX 40, L40
 		90 # H100
 	)
 endif()

--- a/unidock/README.md
+++ b/unidock/README.md
@@ -19,12 +19,12 @@ Developed by [DP Technology](https://dp.tech/en), [Hermite®](https://dp.tech/en
 
 Uni-Dock is now available on the new-generation drug computing design platform [Hermite®](https://dp.tech/en/product/hermite) for ultralarge virtual screening.
 
-For further cooperations on developing Uni-Dock and trying out Hermite®, please contact us at bd@dp.tech .
+For further cooperations on developing Uni-Dock and trying out Hermite®, please contact us at <bd@dp.tech> .
 
 ## Installation
 
-Uni-Dock supports NVIDIA GPUs on Linux platform.
-[CUDA toolkit](https://developer.nvidia.com/cuda-downloads) is required.
+Uni-Dock officially supports NVIDIA GPUs with [compute capability](https://en.wikipedia.org/wiki/CUDA#GPUs_supported) >= 7.0 on Linux platform.
+The performance is not guaranteed on legacy GPU models. To build Uni-Dock with a customized compute capability, please change the `CMAKE_CUDA_ARCHITECTURES` variable in `CMakeLists.txt` to the corresponding value.
 
 ### Building from source
 
@@ -32,13 +32,13 @@ Uni-Dock supports NVIDIA GPUs on Linux platform.
 
      - CUDA toolkit: Please refer to the [installation tutorial](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) provided by nvidia.
      - CMake >= 3.16
-     - A C++ compiler (should be compatible with NVCC; `g++` works for most cases)
+     - A C++ compiler (should be [compatible with NVCC](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#host-compiler-support-policy); `g++` works for most cases)
      - Boost >= 1.72
-          
+
           ```bash
           sudo apt install libboost-system-dev libboost-thread-dev libboost-serialization-dev libboost-filesystem-dev libboost-program-options-dev libboost-timer-dev
           ```
-          
+
           Alternatively, install from [boost source codes](https://www.boost.org/users/download/) or from [anaconda](https://anaconda.org/anaconda/libboost) with `conda install -c anaconda libboost`
 
 2. Clone repo or retrieve source code from [release page](https://github.com/dptech-corp/Uni-Dock/releases):
@@ -47,8 +47,8 @@ Uni-Dock supports NVIDIA GPUs on Linux platform.
    git clone https://github.com/dptech-corp/Uni-Dock.git
    ```
 
-4. Build Uni-Dock using CMake:
-     
+3. Build Uni-Dock using CMake:
+
      ```bash
      cd Uni-Dock/unidock
      cmake -B build
@@ -57,12 +57,13 @@ Uni-Dock supports NVIDIA GPUs on Linux platform.
                            # Otherwise, prepend the building directory to your `PATH` environment variable.
      ```
 
-
 code foramt
+
 ```shell
 cd ./build/
 make clang-format
 ```
+
 ### Using binary
 
 Please download the latest binary of Uni-Dock at the assets tab of [the Release page](https://github.com/dptech-corp/Uni-Dock/releases).
@@ -78,7 +79,7 @@ To launch a Uni-Dock job, the most important parameters are as follows:
 
 - `--receptor`: filepath of the receptor (PDBQT)
 - `--gpu_batch`: filepath of the ligands to dock with GPU (PDBQT), enter multiple at a time, separated by spaces (" ")
-- `--search_mode`: computational complexity, choice in [*`fast`*, *`balance`*, and *`detail`*].
+- `--search_mode`: computational complexity, choose in \[*`fast`*, *`balance`*, and *`detail`*].
 
 ***Advanced options***
 `--search_mode` is the recommended setting of `--exhaustiveness` and `--max_step`, with three combinations called `fast`, `balance`, and `detail`.
@@ -205,7 +206,7 @@ If you used Uni-Dock in your work, please cite:
 Yu, Y., Cai, C., Wang, J., Bo, Z., Zhu, Z., & Zheng, H. (2023).
 Uni-Dock: GPU-Accelerated Docking Enables Ultralarge Virtual Screening.
 Journal of Chemical Theory and Computation.
-https://doi.org/10.1021/acs.jctc.2c01145
+<https://doi.org/10.1021/acs.jctc.2c01145>
 
 Tang, S., Chen, R., Lin, M., Lin, Q., Zhu, Y., Ding, J., ... & Wu, J. (2022).
 Accelerating autodock vina with gpus. Molecules, 27(9), 3041.
@@ -225,7 +226,7 @@ DOI 10.1002/jcc.21334
 ## FAQ
 
 1. The GPU encounters out-of-memory error.
-     
+
      Uni-Dock estimates the number of ligands put into GPU memory in one pass based on the available GPU memory size. If it fails, please use `--max_gpu_memory` to limit the usage of GPU memory size by Uni-Dock.
 
 2. I want to put all my ligands in `--gpu_batch`, but it exceeds the maximum command line length that linux can accept.
@@ -235,13 +236,14 @@ DOI 10.1002/jcc.21334
 3. Uni-Dock computes slowly for few (<10) ligands.
 
      The optimal application of Uni-Dock occurs in scenarios where one binding pocket interacts with numerous (in an order of 1000) ligands. As the number of ligands within a single computational batch increases, the average processing speed improves. In instances where only a few ligands are present for one binding pocket, the overhead proportion becomes considerably large, leading to slower computational performance.
-     
-### Addendum to "FAQ 3 - Uni-Dock computes slowly for few (<10) ligands.":
+
+### Addendum to "FAQ 3 - Uni-Dock computes slowly for few (<10) ligands."
 
 The `paired_batch` mode provides a mechanism to accelerate simultaneous 1:1 docking in batches using Vina scoring, using CUDA streams. To run docking using this mode, invoke unidock with the parameter `--paired_batch_size` value >0, with the protein:ligand configurations passed in JSON form using `--ligand_index`. The JSON file should use schema defined in paired_batching.schema.json.
 
 A sample input data.json is as below, complying to the schema:
-```
+
+```json
 {
     "7LCU": {
         "protein": "molecular_docking/PoseBuster/7LCU/7LCU_receptor.pdbqt",
@@ -258,5 +260,6 @@ A sample input data.json is as below, complying to the schema:
 
 A typical usage using paired_batch mode is as shown below, with batch size of 10.
 
-`build/unidock --paired_batch_size 10 --ligand_index data_pb1.json --size_x 25 --size_y 25 --size_z 25 --dir test/prof_25_1024_80 --exhaustiveness 1024 --max_step 80 --seed 5`
-
+```bash
+unidock --paired_batch_size 10 --ligand_index data_pb1.json --size_x 25 --size_y 25 --size_z 25 --dir test/prof_25_1024_80 --exhaustiveness 1024 --max_step 80 --seed 5
+```


### PR DESCRIPTION
The developers of Uni-Dock plan to support GPU models starting from Tesla V100.