### PR TITLE
Build: disable sm_90 arch for forward compatibility on CUDA 11.2

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -26,12 +26,10 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
   set(CMAKE_CUDA_ARCHITECTURES
     70 # V100
-
     # 75 # RTX 20, T4
     80 # A100, A800
-
     # 86 # RTX 30 89 # RTX 40, L40
-    90 # H100
+    # 90 # H100
   )
 endif()
 


### PR DESCRIPTION
Fix #94 