### PR TITLE
Docs: add cuda toolkit requirement

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     # 75 # RTX 20, T4
     80 # A100, A800
     # 86 # RTX 30 89 # RTX 40, L40
-    # 90 # H100
+    90 # H100
   )
 endif()
 

--- a/unidock/README.md
+++ b/unidock/README.md
@@ -17,7 +17,7 @@ The performance is not guaranteed on legacy GPU models. To build Uni-Dock with a
 
 1. Install dependencies
 
-     - CUDA toolkit: Please refer to the [installation tutorial](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) provided by nvidia.
+     - CUDA toolkit >= 11.8: Please refer to the [installation tutorial](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) provided by nvidia.
      - CMake >= 3.16
      - A C++ compiler (should be [compatible with NVCC](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#host-compiler-support-policy); `g++` works for most cases)
      - Boost >= 1.72


### PR DESCRIPTION
Warp-level operations requires cuda toolkit >= 11.8. 
Reverts #95.