### PR TITLE
Enhance run info

### DIFF
--- a/unidock/src/main/main.cpp
+++ b/unidock/src/main/main.cpp
@@ -1012,7 +1012,7 @@ bug reporting, license agreements, and more information.      \n";
                     max_num_lig_pairs = std::max(max_num_lig_pairs,num_lig_pairs_vector.at(i));
                 }
                 
-                printf("max_num_atoms%ld\n",max_num_atoms);
+                printf("max_num_atoms:%ld\n",max_num_atoms);
                 printf("max_num_torsions:%ld\n",max_num_torsions);
                 printf("max_num_rigids:%ld\n",max_num_rigids);
                 printf("max_num_lig_pairs:%ld\n",max_num_lig_pairs);
@@ -1038,13 +1038,13 @@ bug reporting, license agreements, and more information.      \n";
                 printMaxValues(smallGroup);
                 
                 std::cout << "Medium Group:" << std::endl;
-                printMaxValues(mediumGroup);
+                if (!mediumGroup.empty()) printMaxValues(mediumGroup);
                 
                 std::cout << "Large Group:" << std::endl;
-                printMaxValues(largeGroup);
+                if (!largeGroup.empty()) printMaxValues(largeGroup);
                 
                 std::cout << "Extra Large Group:" << std::endl;
-                printMaxValues(extraLargeGroup);
+                if (!extraLargeGroup.empty()) printMaxValues(extraLargeGroup);
                 int processed_ligands_smile = 0;
                 int smile_batch_id = 0;
                 int processed_ligands_medium = 0;


### PR DESCRIPTION
1. Add a missing colon.
2. Skip printing information for empty groups. Currently, the printed message would be:

```
Medium Group:
Max num_atoms: -2147483648 Max num_torsions: -2147483648 Max num_rigids: -2147483648 Max num_lig_pairs: -2147483648
Group size: 0
Large Group:
Max num_atoms: -2147483648 Max num_torsions: -2147483648 Max num_rigids: -2147483648 Max num_lig_pairs: -2147483648
Group size: 0
Extra Large Group:
Max num_atoms: -2147483648 Max num_torsions: -2147483648 Max num_rigids: -2147483648 Max num_lig_pairs: -2147483648
Group size: 0
```

Applying this commit would change this to:

```
Medium Group:
Large Group:
Extra Large Group:
```