### PR TITLE
fix: correct usage of boost::filesystem::path::extension

### DIFF
--- a/unidock/src/main/simulation_container.h
+++ b/unidock/src/main/simulation_container.h
@@ -327,8 +327,7 @@ struct simulation_container {
             complex_property& cp
                 = m_ptr_complex_property_holder->m_properties[m_successful_property_count];
 
-            if (boost::filesystem::extension(m_ligand_config_paths[id].path().string())
-                == ".json") {
+            if (m_ligand_config_paths[id].path().extension().string() == ".json") {
                 try {
                     success_filled = fill_config_from_json(
                         cp, m_ligand_config_paths[id].path().string(),


### PR DESCRIPTION
This pull request includes a change to the `simulation_container` structure in the `unidock/src/main/simulation_container.h` file. The change simplifies the code by replacing a call to `boost::filesystem::extension` with a more straightforward method to get the file extension.

Code simplification:

* [`unidock/src/main/simulation_container.h`](diffhunk://#diff-5d50e9bfd107636df11dcbe5cf30f8db0f7f764651d0e5eaeb09692e7ffb1e51L330-R330): Replaced `boost::filesystem::extension` with `path().extension().string()` to determine the file extension of `m_ligand_config_paths[id].path()`.