### PR TITLE
Update main.cpp . CLASSIFY LIGANDS WITH 160-300 ATOMS IN MaxGroup

### DIFF
--- a/unidock/src/main/main.cpp
+++ b/unidock/src/main/main.cpp
@@ -109,6 +109,11 @@ void classifyLigands(const std::vector<Ligand>& ligands,std::vector<Ligand> &sma
         } else if (lig.num_atoms <= atomThresholds[3] && lig.num_torsions <= torsionThresholds[3] &&
                    lig.num_rigids <= rigidThresholds[3] && lig.num_lig_pairs <= pairThresholds[3]) {
             extraLargeGroup.push_back(lig);
+        } else if (lig.num_atoms <= atomThresholds[4] &&
+                   lig.num_torsions <= torsionThresholds[4] &&
+                   lig.num_rigids <= rigidThresholds[4] &&
+                   lig.num_lig_pairs <= pairThresholds[4]) {
+            maxGroup.push_back(lig);
         } else {
             overflowGroup.push_back(lig);
         }


### PR DESCRIPTION
Added else if to classify ligands wwith number of atoms between 160 and 300. Actual version missed the ligands that should be added to maxGroup.