### PR TITLE
Revert "Update main.cpp . CLASSIFY LIGANDS WITH 160-300 ATOMS IN MaxGroup"

### DIFF
--- a/unidock/src/main/main.cpp
+++ b/unidock/src/main/main.cpp
@@ -109,11 +109,6 @@ void classifyLigands(const std::vector<Ligand>& ligands,std::vector<Ligand> &sma
         } else if (lig.num_atoms <= atomThresholds[3] && lig.num_torsions <= torsionThresholds[3] &&
                    lig.num_rigids <= rigidThresholds[3] && lig.num_lig_pairs <= pairThresholds[3]) {
             extraLargeGroup.push_back(lig);
-        } else if (lig.num_atoms <= atomThresholds[4] &&
-                   lig.num_torsions <= torsionThresholds[4] &&
-                   lig.num_rigids <= rigidThresholds[4] &&
-                   lig.num_lig_pairs <= pairThresholds[4]) {
-            maxGroup.push_back(lig);
         } else {
             overflowGroup.push_back(lig);
         }


### PR DESCRIPTION
Reverts dptech-corp/Uni-Dock#150

The original PR did not pass CI pipeline, hence reverting it.

The current implementation of Uni-Dock classifies ligands to 5 groups, each with a dedicated GPU parameter set. 
To add a new group, I would suggest making a more comprehensive test to demonstrate the speedup brought by the new config.