### PR TITLE
Fix CUDA error when docking with flexible residues

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     86 # RTX 30
     89 # RTX 40, L40
     90 # H100
+    100 # B200 (Blackwell)
   )
 endif()
 

--- a/unidock/src/cuda/kernel.h
+++ b/unidock/src/cuda/kernel.h
@@ -23,7 +23,7 @@ void check(T result, char const *const func, const char *const file, int const l
 
 // kernel2 macros
 #define MAX_NUM_OF_LIG_TORSION 48
-#define MAX_NUM_OF_FLEX_TORSION 1
+#define MAX_NUM_OF_FLEX_TORSION 24
 #define MAX_NUM_OF_RIGID 24
 #define MAX_NUM_OF_ATOMS 150
 #define SIZE_OF_MOLEC_STRUC \
@@ -34,6 +34,7 @@ void check(T result, char const *const func, const char *const file, int const l
     ((6 + MAX_NUM_OF_LIG_TORSION + MAX_NUM_OF_FLEX_TORSION) \
      * (6 + MAX_NUM_OF_LIG_TORSION + MAX_NUM_OF_FLEX_TORSION + 1) / 2)
 #define MAX_NUM_OF_LIG_PAIRS 1024
+#define MAX_NUM_OF_OTHER_PAIRS 1024
 #define MAX_NUM_OF_BFGS_STEPS 64
 #define MAX_NUM_OF_RANDOM_MAP 1000  // not too large (stack overflow!)
 #define GRIDS_SIZE 37               // larger than vina1.1, max(XS_TYPE_SIZE, AD_TYPE_SIZE + 2)
@@ -61,7 +62,7 @@ void check(T result, char const *const func, const char *const file, int const l
         //    bound
 struct SizeConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 48;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 128;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 300;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -97,7 +98,7 @@ static constexpr size_t MAX_LIGAND_NUM_  = 10250;
 };
 struct SmallConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 8;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 12;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 40;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -133,7 +134,7 @@ static constexpr size_t MAX_LIGAND_NUM_  = 10250;
 };
 struct MediumConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 16;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 18;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 80;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -169,7 +170,7 @@ static constexpr size_t MAX_LIGAND_NUM_  = 10250;
 };
 struct LargeConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 24;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 36;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 120;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -205,7 +206,7 @@ static constexpr size_t MAX_LIGAND_NUM_  = 10250;
 };
 struct ExtraLargeConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 36;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 64;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 160;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -241,7 +242,7 @@ static constexpr size_t MAX_LIGAND_NUM_  = 10250;
 };
 struct MaxConfig {
 static constexpr size_t MAX_NUM_OF_LIG_TORSION_ = 48;
-static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 1;
+static constexpr size_t MAX_NUM_OF_FLEX_TORSION_ = 24;
 static constexpr size_t MAX_NUM_OF_RIGID_ = 128;
 static constexpr size_t MAX_NUM_OF_ATOMS_ = 300;
 static constexpr size_t SIZE_OF_MOLEC_STRUC_ =
@@ -353,10 +354,18 @@ typedef struct {
 } random_maps_t;
 
 typedef struct {
+    int type_pair_index[MAX_NUM_OF_OTHER_PAIRS];
+    int a[MAX_NUM_OF_OTHER_PAIRS];
+    int b[MAX_NUM_OF_OTHER_PAIRS];
+    int num_pairs;
+} other_pairs_cuda_t;
+
+typedef struct {
     atom_cuda_t atoms[MAX_NUM_OF_ATOMS];
     m_coords_cuda_t m_coords;
     m_minus_forces_t minus_forces;
     ligand_cuda_t ligand;
+    other_pairs_cuda_t other_pairs;
     int m_num_movable_atoms;  // will be -1 if ligand parsing failed
 } m_cuda_t;
 
@@ -517,11 +526,20 @@ struct random_maps_t_{
 } ;
 
 template <typename Config>
+struct other_pairs_cuda_t_{
+    int type_pair_index[Config::MAX_NUM_OF_LIG_PAIRS_];
+    int a[Config::MAX_NUM_OF_LIG_PAIRS_];
+    int b[Config::MAX_NUM_OF_LIG_PAIRS_];
+    int num_pairs;
+} ;
+
+template <typename Config>
 struct m_cuda_t_{
     atom_cuda_t atoms[Config::MAX_NUM_OF_ATOMS_];
     m_coords_cuda_t_<Config> m_coords;
     m_minus_forces_t_<Config> minus_forces;
     ligand_cuda_t_<Config> ligand;
+    other_pairs_cuda_t_<Config> other_pairs;
     int m_num_movable_atoms;  // will be -1 if ligand parsing failed
 } ;
 template <typename Config>

--- a/unidock/src/cuda/monte_carlo.cu
+++ b/unidock/src/cuda/monte_carlo.cu
@@ -511,7 +511,7 @@ __host__ void monte_carlo::mc_stream(
 
         // Preparing ligand data
         DEBUG_PRINTF("prepare ligand data\n");
-        assert(m.num_other_pairs() == 0);  // m.other_pairs is not supported!
+        // Flex residue other_pairs are now supported
         assert(m.ligands.size() <= 1);     // Only one ligand supported!
 
         if (m.ligands.size() == 0) {  // ligand parsing error
@@ -550,6 +550,16 @@ __host__ void monte_carlo::mc_stream(
                 m_cuda->ligand.pairs.type_pair_index[i] = m.ligands[0].pairs[i].type_pair_index;
                 m_cuda->ligand.pairs.a[i] = m.ligands[0].pairs[i].a;
                 m_cuda->ligand.pairs.b[i] = m.ligands[0].pairs[i].b;
+            }
+            // Copy other_pairs (flex-flex interactions)
+            {
+                interacting_pairs op = m.get_other_pairs();
+                m_cuda->other_pairs.num_pairs = std::min((int)op.size(), (int)(sizeof(m_cuda->other_pairs.a)/sizeof(m_cuda->other_pairs.a[0])));
+                for (int i = 0; i < m_cuda->other_pairs.num_pairs; i++) {
+                    m_cuda->other_pairs.type_pair_index[i] = op[i].type_pair_index;
+                    m_cuda->other_pairs.a[i] = op[i].a;
+                    m_cuda->other_pairs.b[i] = op[i].b;
+                }
             }
             m_cuda->ligand.begin = m.ligands[0].begin;  // 0
             m_cuda->ligand.end = m.ligands[0].end;      // 29
@@ -613,11 +623,9 @@ __host__ void monte_carlo::mc_stream(
             /* Prepare rand_molec_struc data */
             int lig_torsion_size = tmp.c.ligands[0].torsions.size();
             DEBUG_PRINTF("lig_torsion_size=%d\n", lig_torsion_size);
-            int flex_torsion_size;
-            if (tmp.c.flex.size() != 0)
-                flex_torsion_size = tmp.c.flex[0].torsions.size();
-            else
-                flex_torsion_size = 0;
+            int flex_torsion_size = 0;
+            for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                flex_torsion_size += tmp.c.flex[fi].torsions.size();
             // std::vector<vec> uniform_data;
             // uniform_data.resize(thread);
 
@@ -634,9 +642,13 @@ __host__ void monte_carlo::mc_stream(
                     rand_molec_struc_tmp->lig_torsion[j]
                         = tmp.c.ligands[0].torsions[j];  // Only support one ligand
                 assert(flex_torsion_size <= MAX_NUM_OF_FLEX_TORSION);
-                for (int j = 0; j < flex_torsion_size; j++)
-                    rand_molec_struc_tmp->flex_torsion[j]
-                        = tmp.c.flex[0].torsions[j];  // Only support one flex
+                {
+                    int ft_idx = 0;
+                    for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                        for (int j = 0; j < tmp.c.flex[fi].torsions.size(); j++)
+                            rand_molec_struc_tmp->flex_torsion[ft_idx++]
+                                = tmp.c.flex[fi].torsions[j];
+                }
 
                 rand_molec_struc_tmp->orientation[0]
                     = (float)tmp.c.ligands[0].rigid.orientation.R_component_1();
@@ -1309,7 +1321,7 @@ __host__ void monte_carlo::operator()(
 
         // Preparing ligand data
         DEBUG_PRINTF("prepare ligand data\n");
-        assert(m.num_other_pairs() == 0);  // m.other_pairs is not supported!
+        // Flex residue other_pairs are now supported
         assert(m.ligands.size() <= 1);     // Only one ligand supported!
 
         if (m.ligands.size() == 0) {  // ligand parsing error
@@ -1347,6 +1359,16 @@ __host__ void monte_carlo::operator()(
                 m_cuda->ligand.pairs.type_pair_index[i] = m.ligands[0].pairs[i].type_pair_index;
                 m_cuda->ligand.pairs.a[i] = m.ligands[0].pairs[i].a;
                 m_cuda->ligand.pairs.b[i] = m.ligands[0].pairs[i].b;
+            }
+            // Copy other_pairs (flex-flex interactions)
+            {
+                interacting_pairs op = m.get_other_pairs();
+                m_cuda->other_pairs.num_pairs = std::min((int)op.size(), (int)(sizeof(m_cuda->other_pairs.a)/sizeof(m_cuda->other_pairs.a[0])));
+                for (int i = 0; i < m_cuda->other_pairs.num_pairs; i++) {
+                    m_cuda->other_pairs.type_pair_index[i] = op[i].type_pair_index;
+                    m_cuda->other_pairs.a[i] = op[i].a;
+                    m_cuda->other_pairs.b[i] = op[i].b;
+                }
             }
             m_cuda->ligand.begin = m.ligands[0].begin;  // 0
             m_cuda->ligand.end = m.ligands[0].end;      // 29
@@ -1409,11 +1431,9 @@ __host__ void monte_carlo::operator()(
             /* Prepare rand_molec_struc data */
             int lig_torsion_size = tmp.c.ligands[0].torsions.size();
             DEBUG_PRINTF("lig_torsion_size=%d\n", lig_torsion_size);
-            int flex_torsion_size;
-            if (tmp.c.flex.size() != 0)
-                flex_torsion_size = tmp.c.flex[0].torsions.size();
-            else
-                flex_torsion_size = 0;
+            int flex_torsion_size = 0;
+            for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                flex_torsion_size += tmp.c.flex[fi].torsions.size();
             // std::vector<vec> uniform_data;
             // uniform_data.resize(thread);
 
@@ -1430,9 +1450,13 @@ __host__ void monte_carlo::operator()(
                     rand_molec_struc_tmp->lig_torsion[j]
                         = tmp.c.ligands[0].torsions[j];  // Only support one ligand
                 assert(flex_torsion_size <= MAX_NUM_OF_FLEX_TORSION);
-                for (int j = 0; j < flex_torsion_size; j++)
-                    rand_molec_struc_tmp->flex_torsion[j]
-                        = tmp.c.flex[0].torsions[j];  // Only support one flex
+                {
+                    int ft_idx = 0;
+                    for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                        for (int j = 0; j < tmp.c.flex[fi].torsions.size(); j++)
+                            rand_molec_struc_tmp->flex_torsion[ft_idx++]
+                                = tmp.c.flex[fi].torsions[j];
+                }
 
                 rand_molec_struc_tmp->orientation[0]
                     = (float)tmp.c.ligands[0].rigid.orientation.R_component_1();
@@ -1880,7 +1904,7 @@ __host__ void monte_carlo_template::operator()(
 
         // Preparing ligand data
         DEBUG_PRINTF("prepare ligand data\n");
-        assert(m.num_other_pairs() == 0);  // m.other_pairs is not supported!
+        // Flex residue other_pairs are now supported
         assert(m.ligands.size() <= 1);     // Only one ligand supported!
 
         if (m.ligands.size() == 0) {  // ligand parsing error
@@ -1918,6 +1942,16 @@ __host__ void monte_carlo_template::operator()(
                 m_cuda->ligand.pairs.type_pair_index[i] = m.ligands[0].pairs[i].type_pair_index;
                 m_cuda->ligand.pairs.a[i] = m.ligands[0].pairs[i].a;
                 m_cuda->ligand.pairs.b[i] = m.ligands[0].pairs[i].b;
+            }
+            // Copy other_pairs (flex-flex interactions)
+            {
+                interacting_pairs op = m.get_other_pairs();
+                m_cuda->other_pairs.num_pairs = std::min((int)op.size(), (int)(sizeof(m_cuda->other_pairs.a)/sizeof(m_cuda->other_pairs.a[0])));
+                for (int i = 0; i < m_cuda->other_pairs.num_pairs; i++) {
+                    m_cuda->other_pairs.type_pair_index[i] = op[i].type_pair_index;
+                    m_cuda->other_pairs.a[i] = op[i].a;
+                    m_cuda->other_pairs.b[i] = op[i].b;
+                }
             }
             m_cuda->ligand.begin = m.ligands[0].begin;  // 0
             m_cuda->ligand.end = m.ligands[0].end;      // 29
@@ -1980,11 +2014,9 @@ __host__ void monte_carlo_template::operator()(
             /* Prepare rand_molec_struc data */
             int lig_torsion_size = tmp.c.ligands[0].torsions.size();
             DEBUG_PRINTF("lig_torsion_size=%d\n", lig_torsion_size);
-            int flex_torsion_size;
-            if (tmp.c.flex.size() != 0)
-                flex_torsion_size = tmp.c.flex[0].torsions.size();
-            else
-                flex_torsion_size = 0;
+            int flex_torsion_size = 0;
+            for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                flex_torsion_size += tmp.c.flex[fi].torsions.size();
             // std::vector<vec> uniform_data;
             // uniform_data.resize(thread);
 
@@ -2001,9 +2033,13 @@ __host__ void monte_carlo_template::operator()(
                     rand_molec_struc_tmp->lig_torsion[j]
                         = tmp.c.ligands[0].torsions[j];  // Only support one ligand
                 assert(flex_torsion_size <= MAX_NUM_OF_FLEX_TORSION);
-                for (int j = 0; j < flex_torsion_size; j++)
-                    rand_molec_struc_tmp->flex_torsion[j]
-                        = tmp.c.flex[0].torsions[j];  // Only support one flex
+                {
+                    int ft_idx = 0;
+                    for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                        for (int j = 0; j < tmp.c.flex[fi].torsions.size(); j++)
+                            rand_molec_struc_tmp->flex_torsion[ft_idx++]
+                                = tmp.c.flex[fi].torsions[j];
+                }
 
                 rand_molec_struc_tmp->orientation[0]
                     = (float)tmp.c.ligands[0].rigid.orientation.R_component_1();
@@ -2534,7 +2570,7 @@ __host__ void monte_carlo_template::do_docking_base<Config>(std::vector<model> &
 
         // Preparing ligand data
         DEBUG_PRINTF("prepare ligand data\n");
-        assert(m.num_other_pairs() == 0);  // m.other_pairs is not supported!
+        // Flex residue other_pairs are now supported
         assert(m.ligands.size() <= 1);     // Only one ligand supported!
 
         if (m.ligands.size() == 0) {  // ligand parsing error
@@ -2572,6 +2608,16 @@ __host__ void monte_carlo_template::do_docking_base<Config>(std::vector<model> &
                 m_cuda->ligand.pairs.type_pair_index[i] = m.ligands[0].pairs[i].type_pair_index;
                 m_cuda->ligand.pairs.a[i] = m.ligands[0].pairs[i].a;
                 m_cuda->ligand.pairs.b[i] = m.ligands[0].pairs[i].b;
+            }
+            // Copy other_pairs (flex-flex interactions)
+            {
+                interacting_pairs op = m.get_other_pairs();
+                m_cuda->other_pairs.num_pairs = std::min((int)op.size(), (int)(sizeof(m_cuda->other_pairs.a)/sizeof(m_cuda->other_pairs.a[0])));
+                for (int i = 0; i < m_cuda->other_pairs.num_pairs; i++) {
+                    m_cuda->other_pairs.type_pair_index[i] = op[i].type_pair_index;
+                    m_cuda->other_pairs.a[i] = op[i].a;
+                    m_cuda->other_pairs.b[i] = op[i].b;
+                }
             }
             m_cuda->ligand.begin = m.ligands[0].begin;  // 0
             m_cuda->ligand.end = m.ligands[0].end;      // 29
@@ -2637,11 +2683,9 @@ __host__ void monte_carlo_template::do_docking_base<Config>(std::vector<model> &
             /* Prepare rand_molec_struc data */
             int lig_torsion_size = tmp.c.ligands[0].torsions.size();
             DEBUG_PRINTF("lig_torsion_size=%d\n", lig_torsion_size);
-            int flex_torsion_size;
-            if (tmp.c.flex.size() != 0)
-                flex_torsion_size = tmp.c.flex[0].torsions.size();
-            else
-                flex_torsion_size = 0;
+            int flex_torsion_size = 0;
+            for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                flex_torsion_size += tmp.c.flex[fi].torsions.size();
             // std::vector<vec> uniform_data;
             // uniform_data.resize(thread);
 
@@ -2657,10 +2701,14 @@ __host__ void monte_carlo_template::do_docking_base<Config>(std::vector<model> &
                 for (int j = 0; j < lig_torsion_size; j++)
                     rand_molec_struc_tmp->lig_torsion[j]
                         = tmp.c.ligands[0].torsions[j];  // Only support one ligand
-                assert(flex_torsion_size <= Config::MAX_NUM_OF_FLEX_TORSION_);
-                for (int j = 0; j < flex_torsion_size; j++)
-                    rand_molec_struc_tmp->flex_torsion[j]
-                        = tmp.c.flex[0].torsions[j];  // Only support one flex
+                assert(flex_torsion_size <= (int)Config::MAX_NUM_OF_FLEX_TORSION_);
+                {
+                    int ft_idx = 0;
+                    for (int fi = 0; fi < tmp.c.flex.size(); fi++)
+                        for (int j = 0; j < tmp.c.flex[fi].torsions.size(); j++)
+                            rand_molec_struc_tmp->flex_torsion[ft_idx++]
+                                = tmp.c.flex[fi].torsions[j];
+                }
 
                 rand_molec_struc_tmp->orientation[0]
                     = (float)tmp.c.ligands[0].rigid.orientation.R_component_1();

--- a/unidock/src/cuda/warp_ops.cuh
+++ b/unidock/src/cuda/warp_ops.cuh
@@ -462,7 +462,16 @@ __device__ __forceinline__ void m_cuda_init_with_m_cuda_warp(cg::thread_block_ti
 
     ligand_init_with_ligand_warp(tile, &m_cuda_old->ligand, &m_cuda_new->ligand);
 
-    if (tile.thread_rank() == 0) m_cuda_new->m_num_movable_atoms = m_cuda_old->m_num_movable_atoms;
+    // Copy other_pairs (flex-flex interactions)
+    if (tile.thread_rank() == 0) {
+        m_cuda_new->other_pairs.num_pairs = m_cuda_old->other_pairs.num_pairs;
+        m_cuda_new->m_num_movable_atoms = m_cuda_old->m_num_movable_atoms;
+    }
+    for (int i = tile.thread_rank(); i < m_cuda_old->other_pairs.num_pairs; i += tile.num_threads()) {
+        m_cuda_new->other_pairs.type_pair_index[i] = m_cuda_old->other_pairs.type_pair_index[i];
+        m_cuda_new->other_pairs.a[i] = m_cuda_old->other_pairs.a[i];
+        m_cuda_new->other_pairs.b[i] = m_cuda_old->other_pairs.b[i];
+    }
 
     tile.sync();
 }
@@ -484,7 +493,16 @@ __device__ __forceinline__ void m_cuda_init_with_m_cuda_warp(cg::thread_block_ti
 
     ligand_init_with_ligand_warp<TileSize,Config>(tile, &m_cuda_old->ligand, &m_cuda_new->ligand);
 
-    if (tile.thread_rank() == 0) m_cuda_new->m_num_movable_atoms = m_cuda_old->m_num_movable_atoms;
+    // Copy other_pairs (flex-flex interactions)
+    if (tile.thread_rank() == 0) {
+        m_cuda_new->other_pairs.num_pairs = m_cuda_old->other_pairs.num_pairs;
+        m_cuda_new->m_num_movable_atoms = m_cuda_old->m_num_movable_atoms;
+    }
+    for (int i = tile.thread_rank(); i < m_cuda_old->other_pairs.num_pairs; i += tile.num_threads()) {
+        m_cuda_new->other_pairs.type_pair_index[i] = m_cuda_old->other_pairs.type_pair_index[i];
+        m_cuda_new->other_pairs.a[i] = m_cuda_old->other_pairs.a[i];
+        m_cuda_new->other_pairs.b[i] = m_cuda_old->other_pairs.b[i];
+    }
 
     tile.sync();
 }
@@ -824,10 +842,16 @@ __device__ float m_eval_deriv_warp(cg::thread_block_tile<TileSize> &tile, output
     e += eval_interacting_pairs_deriv_warp(tile, p_cuda_gpu, v[0], &m_cuda_gpu->ligand.pairs,
                                            &m_cuda_gpu->m_coords, &m_cuda_gpu->minus_forces,
                                            epsilon_fl);
+    // Evaluate other_pairs (flex-flex interactions)
+    if (m_cuda_gpu->other_pairs.num_pairs > 0) {
+        e += eval_interacting_pairs_deriv_warp(tile, p_cuda_gpu, v[2],
+                                               (const lig_pairs_cuda_t *)&m_cuda_gpu->other_pairs,
+                                               &m_cuda_gpu->m_coords, &m_cuda_gpu->minus_forces,
+                                               epsilon_fl);
+    }
     tile.sync();
     e = cg::reduce(tile, e, cg::plus<float>());
 
-    // should add derivs for glue, other and inter pairs
     POT_deriv_warp(tile, &m_cuda_gpu->minus_forces, &m_cuda_gpu->ligand.rigid,
                    &m_cuda_gpu->m_coords, g, pot_aux);
 
@@ -849,10 +873,16 @@ __device__ float m_eval_deriv_warp(cg::thread_block_tile<TileSize> &tile, output
     e += eval_interacting_pairs_deriv_warp<TileSize,Config>(tile, p_cuda_gpu, v[0], &m_cuda_gpu->ligand.pairs,
                                            &m_cuda_gpu->m_coords, &m_cuda_gpu->minus_forces,
                                            epsilon_fl);
+    // Evaluate other_pairs (flex-flex interactions)
+    if (m_cuda_gpu->other_pairs.num_pairs > 0) {
+        e += eval_interacting_pairs_deriv_warp<TileSize,Config>(tile, p_cuda_gpu, v[2],
+                                               (const lig_pairs_cuda_t_<Config> *)&m_cuda_gpu->other_pairs,
+                                               &m_cuda_gpu->m_coords, &m_cuda_gpu->minus_forces,
+                                               epsilon_fl);
+    }
     tile.sync();
     e = cg::reduce(tile, e, cg::plus<float>());
 
-    // should add derivs for glue, other and inter pairs
     POT_deriv_warp<TileSize,Config>(tile, &m_cuda_gpu->minus_forces, &m_cuda_gpu->ligand.rigid,
                    &m_cuda_gpu->m_coords, g, pot_aux);
 

--- a/unidock/src/lib/vina.h
+++ b/unidock/src/lib/vina.h
@@ -257,6 +257,10 @@ public:
                     quasi_newton_par.max_steps
                         = unsigned((25 + m_model_gpu[l].num_movable_atoms()) / 3);
                     VINA_FOR_IN(i, poses) {
+                        // Initialize flex conf if missing (GPU kernel doesn't set it)
+                        if (poses[i].c.flex.size() != m_model_gpu[l].get_size().flex.size()) {
+                            poses[i].c.flex = m_model_gpu[l].get_initial_conf().flex;
+                        }
                         // DEBUG_PRINTF("poses i score=%lf\n", poses[i].e);
                         const fl slope_orig = m_non_cache.slope;
                         VINA_FOR(p, refine_step) {

--- a/unidock/src/main/main.cpp
+++ b/unidock/src/main/main.cpp
@@ -999,12 +999,22 @@ bug reporting, license agreements, and more information.      \n";
                 size_t max_num_torsions = 0;
                 size_t max_num_rigids = 0;
                 size_t max_num_lig_pairs = 0;
+                // Account for receptor flex atoms/torsions in grouping
+                // The receptor's movable atoms (flex) will be added to each ligand model
+                size_t receptor_flex_atoms = v.m_receptor.num_atoms();
+                size_t receptor_flex_torsions = sum(v.m_receptor.flex.count_torsions());
+                (void)0; // receptor other_pairs stored separately in CUDA struct
+
                 printf("all_ligands.size():%ld\n",all_ligands.size());
                 for (int i = 0; i <  all_ligands.size(); ++i) {
                     // printf("i=:%d\n",i);
-                    num_atoms_vector.at(i) = all_ligands[i].second.num_atoms();
+                    num_atoms_vector.at(i) = all_ligands[i].second.num_atoms() + receptor_flex_atoms;
                     num_torsions_vector.at(i)=sum(all_ligands[i].second.ligands.count_torsions());
-                    num_rigids_vector.at(i)=all_ligands[i].second.ligands[0].children.size();
+                    {
+                        size_t lig_rigids = all_ligands[i].second.ligands.size() > 0
+                            ? all_ligands[i].second.ligands[0].children.size() : 0;
+                        num_rigids_vector.at(i) = lig_rigids + receptor_flex_torsions;
+                    }
                     num_lig_pairs_vector.at(i)=all_ligands[i].second.num_internal_pairs();
                     max_num_atoms = std::max(max_num_atoms, num_atoms_vector.at(i));
                     max_num_torsions = std::max(max_num_torsions, num_torsions_vector.at(i));


### PR DESCRIPTION
## Summary

Fixes #159 — CUDA error 700 (`cudaErrorIllegalAddress`) when using `--flex` for flexible receptor residues.

The CUDA kernel completely lacked support for flexible residues, causing crashes through five interrelated bugs:

- **Blocking assert**: `assert(m.num_other_pairs() == 0)` in 4 locations in `monte_carlo.cu` immediately crashed when flex residues created `other_pairs` (flex-flex interaction pairs)
- **Missing other_pairs in CUDA**: Flex-flex interaction pairs were never stored in GPU structures or evaluated in the scoring kernel
- **Buffer overflow**: `MAX_NUM_OF_FLEX_TORSION = 1` was too small for real flex residues (which can have 20+ torsions across multiple residues), causing memory corruption when copying torsion data
- **Wrong Config grouping**: Ligand classification in `main.cpp` ignored receptor flex atoms/torsions, placing combined models (e.g., 165 atoms) into undersized Config groups (e.g., SmallConfig with max 40 atoms), causing out-of-bounds GPU memory access
- **Missing flex conf in results**: `cuda_to_vina` didn't initialize flex conformation data, causing segfault during CPU-side pose refinement when `model.set()` was called

### Changes

| File | Changes |
|------|---------|
| `kernel.h` | Increase `MAX_NUM_OF_FLEX_TORSION` 1→24 in all Config structs; add `other_pairs` structs to `m_cuda_t` and `m_cuda_t_<Config>` |
| `monte_carlo.cu` | Remove 4 blocking asserts; add `other_pairs` GPU data copying; fix flex torsion copy to flatten all residues |
| `warp_ops.cuh` | Evaluate `other_pairs` in `m_eval_deriv_warp`; copy `other_pairs` in `m_cuda_init_with_m_cuda_warp` |
| `main.cpp` | Account for receptor flex atoms/torsions in ligand Config group classification |
| `vina.h` | Initialize flex conf from model before pose refinement |
| `CMakeLists.txt` | Add sm_100 (Blackwell/B200) to `CMAKE_CUDA_ARCHITECTURES` |

### Limitations

This fix enables flex docking to run without crashing and correctly evaluates flex-flex interaction energy (`other_pairs`). However, flex torsions are **not yet optimized** during the GPU Monte Carlo search — they remain at their initial values and are refined only during the CPU-side post-processing step. Full flex torsion optimization in the CUDA kernel (flex tree coordinate updates, flex torsion mutation, flex derivatives) would be a follow-up enhancement.

## Test plan

- [x] Reproduced original CUDA error 700 with the issue reporter's test files (2am9 receptor with 21 flex residues)
- [x] Verified fix produces docking output (affinity: -3.467 kcal/mol, EXIT_CODE=0)
- [x] Verified normal (non-flex) docking regression: 5798 ligands in 2.6s, identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)