### PR TITLE
Fix CUDA error 700 (illegal address) in gpu_batch mode

### DIFF
--- a/unidock/src/cuda/monte_carlo.cu
+++ b/unidock/src/cuda/monte_carlo.cu
@@ -1478,7 +1478,7 @@ __host__ void monte_carlo::operator()(
         std::cout << "with multi bias ";
 
         checkCUDA(cudaMalloc(&ig_cuda_gpu, ig_cuda_size * num_of_ligands));
-        checkCUDA(cudaMemset(&ig_cuda_gpu, 0, ig_cuda_size * num_of_ligands));
+        checkCUDA(cudaMemset(ig_cuda_gpu, 0, ig_cuda_size * num_of_ligands));
         for (int l = 0; l < num_of_ligands; ++l) {
             if (ig.get_atu() == atom_type::XS) {
                 cache ig_tmp(ig.get_gd(), ig.get_slope());


### PR DESCRIPTION
## Summary
- Fixes #115, #118, #136: CUDA error 700 (cudaErrorIllegalAddress) during gpu_batch mode

**Root cause**: `cudaMemset(&ig_cuda_gpu, 0, ...)` at monte_carlo.cu:1481 passes the address of the local pointer variable (on CPU stack) instead of the GPU buffer pointer. This corrupts the `ig_cuda_gpu` pointer, causing all subsequent GPU memory accesses to hit illegal addresses.

The correct pattern `cudaMemsetAsync(ig_cuda_gpu, 0, ...)` is used at line 687 for the same purpose. This is a one-character fix removing the erroneous `&`.

### Why it manifests on second+ batches
The first batch may succeed because the corrupted pointer happens to still partially overlap valid GPU memory. By the second batch, the pointer is garbage → illegal address at cudaDeviceSynchronize.

## Test plan
- [ ] Build with CUDA and verify compilation
- [ ] Run gpu_batch with multiple batches → should complete without CUDA error 700

🤖 Generated with [Claude Code](https://claude.com/claude-code)