### PR TITLE
Fix intermittent SIGSEGV from NaN/non-unit axis in angle_to_quaternion

### DIFF
--- a/unidock/src/lib/quaternion.cpp
+++ b/unidock/src/lib/quaternion.cpp
@@ -35,15 +35,20 @@ bool eq(
 }
 
 qt angle_to_quaternion(const vec& axis, fl angle) {  // axis is assumed to be a unit vector
-    // assert(eq(tvmet::norm2(axis), 1));
-    if (!eq(axis.norm(), 1)) {
-        printf("angle_to_quaternion axis.norm=%f, failed\n", axis.norm());
+    fl n = axis.norm();
+    if (std::isnan(n) || n < epsilon_fl) {
+        // Degenerate axis (NaN or zero-length): return identity quaternion (no rotation)
+        return qt_identity;
     }
-    assert(eq(axis.norm(), 1));
+    vec normalized_axis = axis;
+    if (!eq(n, 1)) {
+        // Renormalize axis that drifted from unit length due to floating-point precision
+        normalized_axis = axis / n;
+    }
     normalize_angle(angle);  // this is probably only necessary if angles can be very big
     fl c = std::cos(angle / 2);
     fl s = std::sin(angle / 2);
-    return qt(c, s * axis[0], s * axis[1], s * axis[2]);
+    return qt(c, s * normalized_axis[0], s * normalized_axis[1], s * normalized_axis[2]);
 }
 
 qt angle_to_quaternion(const vec& rotation) {


### PR DESCRIPTION
## Summary
- Fixes #160: Intermittent "angle_to_quaternion axis.norm=-nan, failed" crash

**Root cause**: `angle_to_quaternion(axis, angle)` assumes the axis is a unit vector, but floating-point precision drift from GPU matrix-vector multiplication (segment transformations in tree.h) can produce non-unit or NaN axes. The existing `assert()` is stripped in release builds, leaving no protection.

**Fix**: Add robust handling:
- NaN or zero-length axis → return identity quaternion (no rotation)
- Near-unit axis → renormalize before use
- Well-behaved axis → unchanged behavior

This makes the function resilient to floating-point drift without changing docking results for well-behaved inputs.

## Test plan
- [ ] Build with CUDA and verify compilation
- [ ] Run large-scale docking (15k+ ligands) → should not crash with quaternion error
- [ ] Verify docking results are unchanged for normal inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)