### PR TITLE
Fix SIGSEGV with unsupported atom types in SDF ligands

### DIFF
--- a/.github/workflows/ci_test_tools.yml
+++ b/.github/workflows/ci_test_tools.yml
@@ -85,7 +85,7 @@ jobs:
         echo y | bash CDPKit.sh --cpack_skip_license --include-subdir
         rm CDPKit.sh
 
-        mamba install -y ipython openbabel -c conda-forge
+        mamba install -y python=3.12 ipython openbabel -c conda-forge
         pip install .
 
     - name: run unit-test

--- a/.github/workflows/ci_test_tools.yml
+++ b/.github/workflows/ci_test_tools.yml
@@ -85,7 +85,7 @@ jobs:
         echo y | bash CDPKit.sh --cpack_skip_license --include-subdir
         rm CDPKit.sh
 
-        mamba install -y python=3.12 ipython openbabel -c conda-forge
+        mamba install -y ipython openbabel -c conda-forge
         pip install .
 
     - name: run unit-test

--- a/unidock/src/lib/parse_pdbqt.cpp
+++ b/unidock/src/lib/parse_pdbqt.cpp
@@ -136,12 +136,17 @@ parsed_atom parse_sdf_atom_string(const std::string& str, int number) {
         name = name.substr(0, 1);
     }
     sz ad = string_to_ad_type(name);
-    // std::cout << "parse_sdf_atom_string, name=" << name << ", ad=" << ad << std::endl;
     fl charge = 0;
 
     parsed_atom tmp(ad, charge, coords, 0, number);
 
-    return tmp;
+    if (is_non_ad_metal_name(name)) tmp.xs = XS_TYPE_Met_D;
+    if (tmp.acceptable_type())
+        return tmp;
+    else
+        throw struct_parse_error(
+            "Atom type " + name + " is not a valid AutoDock type "
+            "(see src/lib/atom_constants.h). Atom will be ignored in SDF file.");
 }
 
 struct atom_reference {


### PR DESCRIPTION
## Summary
- Adds atom type validation to `parse_sdf_atom_string()` in `parse_pdbqt.cpp`, matching the existing check in `parse_pdbqt_atom_string()`
- Prevents segfault when SDF files contain unsupported elements (e.g., boron "B") that return `AD_TYPE_SIZE` sentinel, causing out-of-bounds grid access
- Adds missing `is_non_ad_metal_name()` check for non-AD metal types in SDF parser

## Root Cause
`parse_sdf_atom_string()` did not validate atom types. When an SDF contains boron or other unsupported elements, `string_to_ad_type("B")` returns `AD_TYPE_SIZE` (35). The atom was added to the model without validation, and later grid evaluation accessed `m_grids[35]` out of bounds, causing a segfault.

The PDBQT parser already had this validation via `acceptable_type()` + `struct_parse_error`, but the SDF parser was missing it entirely.

## Test plan
- [ ] Dock an SDF file containing boron atoms — should now skip the ligand with an error message instead of crashing
- [ ] Dock a normal SDF file — should work exactly as before
- [ ] Verify PDBQT docking is unaffected

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)