### PR TITLE
Fix segfault when ligands fail to parse in batch mode

### DIFF
--- a/unidock/src/main/main.cpp
+++ b/unidock/src/main/main.cpp
@@ -1003,6 +1003,15 @@ bug reporting, license agreements, and more information.      \n";
                 for (int i = 0; i <  all_ligands.size(); ++i) {
                     // printf("i=:%d\n",i);
                     num_atoms_vector.at(i) = all_ligands[i].second.num_atoms();
+                    if (all_ligands[i].second.ligands.empty()) {
+                        // Ligand failed to parse - mark as invalid to avoid segfault
+                        num_torsions_vector.at(i) = 0;
+                        num_rigids_vector.at(i) = 0;
+                        num_lig_pairs_vector.at(i) = 0;
+                        std::cerr << "WARNING: Skipping ligand " << all_ligands[i].first
+                                  << " (failed to parse)" << std::endl;
+                        continue;
+                    }
                     num_torsions_vector.at(i)=sum(all_ligands[i].second.ligands.count_torsions());
                     num_rigids_vector.at(i)=all_ligands[i].second.ligands[0].children.size();
                     num_lig_pairs_vector.at(i)=all_ligands[i].second.num_internal_pairs();


### PR DESCRIPTION
## Summary
- Fixes #112: segfault (SIGSEGV) when using `--ligand_index` with ligands that fail to parse
- `parse_ligand_from_file_no_failure()` returns an empty model (with empty `ligands` vector) when parsing fails, but `main.cpp` accesses `ligands[0]` without checking, causing a crash
- Added a guard that checks for empty `ligands` vector before accessing it, skipping failed ligands with a warning instead of crashing

## Test plan
- [ ] Run Uni-Dock with `--ligand_index` containing a mix of valid and intentionally malformed ligand files
- [ ] Verify that malformed ligands produce a warning message and are skipped gracefully
- [ ] Verify that valid ligands in the same batch are still docked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)