### PR TITLE
Skip out-of-bounds poses instead of reporting FLT_MAX energies (#144)

### DIFF
--- a/unidock/src/lib/vina.cpp
+++ b/unidock/src/lib/vina.cpp
@@ -1588,6 +1588,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
                     = m_model.eval_intramolecular(m_precalculated_byatom, m_non_cache, authentic_v);
         }
         VINA_FOR_IN(i, poses) {
+            if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
             if (m_verbosity > 1) std::cout << "ENERGY FROM SEARCH: " << poses[i].e << "\n";
 
             m_model.set(poses[i].c);
@@ -1624,6 +1625,7 @@ void Vina::global_search(const int exhaustiveness, const int n_poses, const doub
         }
 
         VINA_FOR_IN(i, poses) {
+            if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
             m_model.set(poses[i].c);
 
             // Get RMSD between current pose and best_model
@@ -1787,6 +1789,7 @@ void Vina::global_search_gpu(const int exhaustiveness, const int n_poses, const 
             }
 
             for (int i = 0; i < poses.size(); ++i) {
+                if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
                 if (m_verbosity > 1) std::cout << "ENERGY FROM SEARCH: " << poses[i].e << "\n";
 
                 m_model_gpu[l].set(poses[i].c);
@@ -1827,6 +1830,7 @@ void Vina::global_search_gpu(const int exhaustiveness, const int n_poses, const 
             }
 
             VINA_FOR_IN(i, poses) {
+                if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
                 m_model_gpu[l].set(poses[i].c);
 
                 // Get RMSD between current pose and best_model

--- a/unidock/src/lib/vina.h
+++ b/unidock/src/lib/vina.h
@@ -283,6 +283,7 @@ public:
             }
 
             for (int i = 0; i < poses.size(); ++i) {
+                if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
                 if (m_verbosity > 1) std::cout << "ENERGY FROM SEARCH: " << poses[i].e << "\n";
 
                 m_model_gpu[l].set(poses[i].c);
@@ -323,6 +324,7 @@ public:
             }
 
             VINA_FOR_IN(i, poses) {
+                if (!not_max(poses[i].e)) continue;  // skip out-of-bounds poses
                 m_model_gpu[l].set(poses[i].c);
 
                 // Get RMSD between current pose and best_model


### PR DESCRIPTION
## Summary

- Fixes #144: Unexpected high positive affinity scores and constant "ENERGY FROM SEARCH" value of 3.4e+38 (FLT_MAX)

**Root cause**: When GPU BFGS optimization moves a ligand pose outside the grid box, CPU refinement (with increasing penalty slopes) tries to pull it back. If after all `refine_step` iterations the pose is still out of bounds, `vina.cpp:1801` sets `poses[i].e = max_fl` (= FLT_MAX since `fl = float`). These invalid poses were still being rescored and written to output, producing confusing high positive affinity values.

**Fix**: Add `not_max(poses[i].e)` guards at all 6 scoring/output loops to skip poses marked as out-of-bounds. `not_max()` is an existing utility in `common.h` that checks `x < 0.1 * max_fl`.

### Files changed
- `unidock/src/lib/vina.cpp` — 4 guards (2 scoring loops + 2 RMSD/output loops)
- `unidock/src/lib/vina.h` — 2 guards (1 scoring loop + 1 RMSD/output loop)

## Test plan

- [ ] Build with CUDA and verify compilation
- [ ] Dock 90k ligands with box 20×20×20 → out-of-bounds poses should be skipped instead of producing FLT_MAX
- [ ] Normal docking unchanged (no poses skipped when all are within bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)