### PR TITLE
ci: pin python=3.12 for openbabel compatibility

### DIFF
--- a/.github/workflows/ci_test_tools.yml
+++ b/.github/workflows/ci_test_tools.yml
@@ -85,7 +85,7 @@ jobs:
         echo y | bash CDPKit.sh --cpack_skip_license --include-subdir
         rm CDPKit.sh
 
-        mamba install -y ipython openbabel -c conda-forge
+        mamba install -y python=3.12 ipython openbabel -c conda-forge
         pip install .
 
     - name: run unit-test


### PR DESCRIPTION
## Summary
- Miniforge 26.x (released Feb 2026) ships Python 3.13 by default, but `openbabel` on conda-forge only has builds up to Python 3.12
- This causes the `install tools` step in Uni-Dock Tools CI/CD to fail for all PRs
- Fix: pin `python=3.12` in the `mamba install` command

## Test plan
- [ ] Verify the `tests` job in Uni-Dock Tools CI/CD passes the `install tools` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)