### PR TITLE
feat: bump CUDA to 12.8 and add Blackwell GPU support

### DIFF
--- a/.github/workflows/ci_test_tools.yml
+++ b/.github/workflows/ci_test_tools.yml
@@ -56,7 +56,7 @@ jobs:
     needs: [flake8,pyright]
     runs-on: nvidia
     container:
-      image: nvidia/cuda:12.2.0-devel-ubuntu22.04
+      image: nvidia/cuda:12.8.0-devel-ubuntu22.04
       options: --gpus all
     steps:
     - name: checkout repo

--- a/.github/workflows/ci_test_unidock.yml
+++ b/.github/workflows/ci_test_unidock.yml
@@ -11,7 +11,7 @@ jobs:
   unidock_test:
     runs-on: nvidia
     container:
-      image: nvidia/cuda:12.2.0-devel-ubuntu22.04
+      image: nvidia/cuda:12.8.0-devel-ubuntu22.04
       options: --gpus all
     steps:
     - name: checkout repo

--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -31,6 +31,8 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     86 # RTX 30
     89 # RTX 40, L40
     90 # H100
+    100 # B100, B200, GB200
+    120 # RTX 50, B40
   )
 endif()
 

--- a/unidock/Dockerfile
+++ b/unidock/Dockerfile
@@ -1,7 +1,7 @@
 # Running this Docker image requires Docker to support NVIDIA GPUs. Please make sure NVIDIA Container Toolkit is configured.
 # See https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html https://github.com/NVIDIA/nvidia-container-toolkit
 
-ARG CUDA_VERSION=12.0.0
+ARG CUDA_VERSION=12.8.0
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 RUN apt-get update && apt install -y cmake \
@@ -17,4 +17,4 @@ RUN cd /opt/unidock && \
 
 # Build this Docker image:
 # cd Uni-Dock-Dev/unidock && \
-# docker build . -f Dockerfile -t unidock --build-arg CUDA_VERSION=12.2.0
+# docker build . -f Dockerfile -t unidock --build-arg CUDA_VERSION=12.8.0


### PR DESCRIPTION
## Summary
- Add `sm_100` (B100, B200, GB200) and `sm_120` (RTX 50, B40) to `CMAKE_CUDA_ARCHITECTURES` for native Blackwell builds
- Bump CI container images from CUDA 12.2 to 12.8 (minimum required for Blackwell native cubins)
- Bump Dockerfile default CUDA version from 12.0 to 12.8

CUDA 12.8 is the minimum toolkit version that can generate native Blackwell cubins. Older toolkits can only run on Blackwell via PTX JIT compilation, which has performance overhead.

## Files changed
- `unidock/CMakeLists.txt` — add architectures 100 and 120
- `unidock/Dockerfile` — default CUDA 12.0 → 12.8
- `.github/workflows/ci_test_unidock.yml` — CUDA 12.2 → 12.8
- `.github/workflows/ci_test_tools.yml` — CUDA 12.2 → 12.8

## Test plan
- [ ] CI builds successfully with CUDA 12.8 container
- [ ] Verify existing GPU architectures (70–90) still compile
- [ ] Verify sm_100 and sm_120 targets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)