### PR TITLE
fix(ci): repair benchmark workflow (run_test.py + data download)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Docker image used"
+        description: "Docker image tag used"
         required: false
         default: "latest"
 jobs:
@@ -20,32 +20,40 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: "3.11"
       - name: Install requirements
         run: |
-          apt update && apt install -y wget unzip
+          apt-get update && apt-get install -y wget unzip curl
           pip install -r scripts/requirements.txt
+      - name: Download benchmark data
+        run: bash getData.sh
 
-      - name: Run molecular docking benchmarks
+      - name: Run molecular docking benchmark (Uni-Dock V1)
+        working-directory: scripts
         run: |
-          python3 scripts/test_molecular_docking.py
-      - name: Upload docking results
+          python3 run_test.py \
+            --version 1 --bin unidock --type molecular_docking \
+            --device 0 --seed 123 \
+            --rootdir "$GITHUB_WORKSPACE" \
+            --savedir "$GITHUB_WORKSPACE/results/molecular_docking"
+      - name: Upload molecular docking results
         uses: actions/upload-artifact@v7
         with:
-          name: molecular_docking_results.csv
-          path: results/results.csv
-      - name: Upload docking metrics
-        uses: actions/upload-artifact@v7
-        with:
-          name: molecular_docking_metrics.csv
-          path: results/metrics.csv
+          name: molecular_docking_results
+          path: |
+            results/molecular_docking/res.csv
+            results/molecular_docking/metrics.csv
 
-      - name: Run virtual screening benchmarks
+      - name: Run virtual screening benchmark (Uni-Dock V1)
+        working-directory: scripts
         run: |
-          rm -rf results
-          python3 scripts/test_virtual_screening.py
+          python3 run_test.py \
+            --version 1 --bin unidock --type virtual_screening \
+            --device 0 --seed 123 \
+            --rootdir "$GITHUB_WORKSPACE" \
+            --savedir "$GITHUB_WORKSPACE/results/virtual_screening"
       - name: Upload virtual screening results
         uses: actions/upload-artifact@v7
         with:
-          name: virtual_screening_results.csv
-          path: results/results.csv
+          name: virtual_screening_results
+          path: results/virtual_screening/res.csv


### PR DESCRIPTION
## Summary

The `Uni-Dock Benchmark` workflow could never run successfully. Three independent breaks:

1. **Dead script names** — it called `scripts/test_molecular_docking.py` and `scripts/test_virtual_screening.py`, which don't exist in `Uni-Dock-Benchmarks-bak` (the suite was refactored to a single `run_test.py` entry point with `run_dock.py`/`run_screen.py`).
2. **No data** — it never downloaded the benchmark dataset, so even the right script would have had nothing to run against.
3. **Missing required args** — `run_test.py` requires `--bin`, `--version`, `--type`, `--savedir`; none were passed.

## Changes

- Call `run_test.py` with explicit args for the Uni-Dock **V1** engine (`--bin unidock`, which is on `PATH` in the `dptechnology/unidock` image).
- Add a `getData.sh` step to fetch the dataset (the `bohrium-api.dp.tech` URL still resolves via redirect; SHA256 in the script matches).
- Point `--rootdir`/`--savedir` at the workspace and upload `res.csv`/`metrics.csv`.

## Verification

Ran this exact command form on an NVIDIA B200 (CUDA 12.8, unidock built for `sm_100`) against the Astex set — it runs end-to-end and produces `res.csv` + `metrics.csv` (0 failures, hit-rate ~0.64–0.72).

## Notes / follow-ups

- The default benchmark box is 30×30×30 Å at 0.375 Å spacing → an **81³ = 531,441-point grid, which exceeds `MAX_NUM_OF_GRID_POINT` (512,000 = 80³)** in `cuda/kernel.h`. Current `main` only "works" because the bounds `assert` is compiled out in Release and the `memcpy` silently overflows. Worth enlarging that buffer (this is the root cause behind #174 / #177).
- The `virtual_screening` step runs the full datasets, one of which (GBA) has ~458k ligands — likely needs a curated subset or a time budget for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
