### PR TITLE
fix: exclude macrocycle glue pairs from the reported affinity (#102/#192)

### DIFF
--- a/unidock/src/lib/model.cpp
+++ b/unidock/src/lib/model.cpp
@@ -1005,14 +1005,15 @@ fl model::eval_intramolecular(const precalculate_byatom& p, const igrid& ig, con
         }
     }
     // printf("e3=%f\n", e);
-    // glue_i - glue_i and glue_i - glue_j interactions (no cutoff)
-    VINA_FOR_IN(i, glue_pairs) {
-        const interacting_pair& pair = glue_pairs[i];
-        fl r2 = vec_distance_sqr(coords[pair.a], coords[pair.b]);
-        fl this_e = p.eval_fast(pair.a, pair.b, r2);
-        curl(this_e, v[2]);
-        e += this_e;
-    }
+    // NOTE: glue_i - glue_j (macrocycle ring-closure) pairs are intentionally NOT
+    // scored here. They are a sampling artifact used only to pull a broken ring
+    // closed during optimization (see eval_deriv), and overlap (r->0) when closed,
+    // which the standard Vina repulsion turns into a large spurious energy. Including
+    // them here (the unbound/intramolecular reference) while the bound intra (evali)
+    // excludes them breaks the cancellation in `inter + intra - intramolecular_energy`,
+    // leaking a huge term into the reported affinity (#102/#192/#37). AutoDock Vina
+    // likewise keeps the glue out of the reported energy. No effect on non-macrocycle
+    // ligands (glue_pairs is empty).
     // printf("e4=%f\n", e);
 
     return e;


### PR DESCRIPTION
## Summary

Macrocycle ligands prepared with Meeko (CG/G "glue" ring-closure atoms) produced wildly wrong, non-reproducible affinities — e.g. **−104 instead of ~−6**, ranging across tens-to-hundreds of kcal/mol between runs (#102, #192; related #37).

**Root cause:** the reported affinity is `inter + intra − intramolecular_energy`. The bound `intra` (`model::evali`) excludes the glue ring-closure pairs, but the unbound reference (`model::eval_intramolecular`) **included** them. So the glue energy didn't cancel and leaked a large spurious term into the affinity — the glue atoms overlap when the ring is closed, so the standard Vina repulsion makes that term huge (UNBOUND **+250** vs AutoDock's **−1.2**).

**Fix:** exclude `glue_pairs` from `eval_intramolecular`, matching the glue-free bound `intra` and AutoDock Vina's convention. Glue is a sampling artifact used only to close a broken ring during optimization — it stays in `eval_deriv` (the BFGS gradient), just not in the reported score.

## Verification (B200, the #102 reporter's receptor + ligand)

| | broken `main` | **this PR** | AutoDock Vina |
|---|---|---|---|
| VINA RESULT | −104 | **−0.84** | −6.04 |
| UNBOUND | +145…+250 | **31.6 (= INTRA, cancels)** | −1.2 (= INTRA) |
| spread over seeds 5/7/99 | −61 / −104 / −127 (~66 kcal) | **−0.84 / +1.0 / −0.82 (~2 kcal)** | — |

- UNBOUND now equals INTRA and cancels, exactly as AutoDock does (its UNBOUND==INTRA) → affinities are sane and reproducible (same-seed deterministic).
- **No regression:** bit-identical to current `main` on the Astex molecular-docking set (max \|Top1 RMSD diff\| = 0.000). The change is a no-op for non-macrocycle ligands (`glue_pairs` is empty).

## Out of scope (separate follow-up)

The absolute affinity (−0.84) is still weaker than AutoDock's (−6.04) because Uni-Dock's **sampling** finds a weaker pose (INTER −1.6 vs −11.3); improving the glue handling during the GPU search so the ring closes as well as AutoDock is a sampling-quality follow-up. This PR fixes the catastrophic scoring/reproducibility bug.

Fixes #102, #192. Related: #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
