### PR TITLE
build: fix FETCH_BOOST=ON against system Boost >= 1.90 (#189)

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -66,12 +66,16 @@ set(REQUIRED_BOOST_COMPONENTS
   system thread serialization
   filesystem program_options timer
 )
+# Header-only Boost used (transitively) by the CUDA sources, e.g. boost/math/quaternion.hpp
+# via quaternion.h -> conf.h -> tree.h -> model.h. Must be part of the fetched Boost so the
+# cuda target resolves these to the fetched headers, not a (possibly newer) system Boost (#189).
+set(REQUIRED_BOOST_CUDA_HEADERS math)
 
 Set(FETCHCONTENT_QUIET FALSE) # Needed to print downloading progress
 
 if(FETCH_BOOST)
   set(BOOST_ENABLE_CMAKE ON)
-  set(BOOST_INCLUDE_LIBRARIES ${REQUIRED_BOOST_COMPONENTS})
+  set(BOOST_INCLUDE_LIBRARIES ${REQUIRED_BOOST_COMPONENTS} ${REQUIRED_BOOST_CUDA_HEADERS})
 
   # downloading a compressed release speeds up the download
   FetchContent_Declare(
@@ -129,6 +133,12 @@ target_include_directories(lib PUBLIC src/lib src/cuda)
 
 add_library(cuda OBJECT src/cuda/monte_carlo.cu src/cuda/precalculate.cu)
 target_include_directories(cuda PUBLIC src/lib src/cuda)
+# When using fetched Boost, link the header-only Boost::math so the CUDA target picks up the
+# fetched Boost headers instead of a newer system Boost (>=1.90 breaks nvcc with a
+# "constexpr constexpr" error in boost/math). See #189.
+if(FETCH_BOOST)
+  target_link_libraries(cuda PUBLIC Boost::math)
+endif()
 
 # >>>>>> Libraries Definitions End
 


### PR DESCRIPTION
## Summary
Fixes #189 — `-DFETCH_BOOST=ON` fails to compile the CUDA sources on hosts that also have **Boost ≥ 1.90** installed.

**Root cause** (from the reporter's diagnosis): the `cuda` OBJECT target's include path is only `src/lib`/`src/cuda`, with no path to the fetched Boost 1.84 headers. `monte_carlo.cu`/`precalculate.cu` pull in `boost/math` transitively (`quaternion.h → conf.h → tree.h → model.h`), so nvcc falls back to the **system** Boost 1.90, whose `boost/math/tools/numeric_limits.hpp` expands to an invalid `constexpr constexpr` under nvcc.

**Fix:** add `math` to `BOOST_INCLUDE_LIBRARIES` (so FetchContent provides `Boost::math`) and link the `cuda` target against `Boost::math` when fetching Boost, so it uses the fetched 1.84 headers. Both edits are inside `if(FETCH_BOOST)` guards.

## Verification (B200, CUDA 12.8)
- `FETCH_BOOST=OFF` (default): configures unchanged — **no regression** (the change is inert when not fetching Boost).
- `FETCH_BOOST=ON`: now configures successfully, `Boost::math` resolves and is linked into the cuda target's build.
- Note: the exact Boost-1.90 conflict couldn't be reproduced in the test image (system Boost 1.74), but the mechanism (cuda target now resolves the fetched headers) is confirmed and matches the reporter's root-cause analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
