### PR TITLE
fix: replace boost::math::quaternion to unblock nvcc with Boost ≥ 1.87

### DIFF
--- a/unidock/src/lib/quaternion.cpp
+++ b/unidock/src/lib/quaternion.cpp
@@ -24,7 +24,7 @@
 #include <iostream>
 
 bool quaternion_is_normalized(const qt& q) {  // not in the interface, used in assertions
-    return eq(quaternion_norm_sqr(q), 1) && eq(boost::math::abs(q), 1);
+    return eq(quaternion_norm_sqr(q), 1) && eq(quaternion_norm(q), 1);
 }
 
 bool eq(
@@ -121,7 +121,7 @@ mat quaternion_to_r3(const qt& q) {
 qt random_orientation(rng& generator) {
     qt q(random_normal(0, 1, generator), random_normal(0, 1, generator),
          random_normal(0, 1, generator), random_normal(0, 1, generator));
-    fl nrm = boost::math::abs(q);
+    fl nrm = quaternion_norm(q);
     if (nrm > epsilon_fl) {
         q /= nrm;
         assert(quaternion_is_normalized(q));

--- a/unidock/src/lib/quaternion.h
+++ b/unidock/src/lib/quaternion.h
@@ -23,13 +23,84 @@
 #ifndef VINA_QUATERNION_H
 #define VINA_QUATERNION_H
 
-#include <boost/math/quaternion.hpp>
 #include <boost/serialization/split_free.hpp>
 
 #include "common.h"
 #include "random.h"
 
-typedef boost::math::quaternion<fl> qt;
+// Custom quaternion type replacing boost::math::quaternion<fl>. Boost's
+// GPU-enabled math headers (Boost >= 1.87) cannot be compiled by nvcc:
+// boost/math/tools/numeric_limits.hpp expands BOOST_MATH_STATIC to `constexpr`
+// under __CUDACC__ and then writes `BOOST_MATH_STATIC constexpr ...`, i.e.
+// `constexpr constexpr`, which nvcc rejects. Since boost::math::quaternion is
+// only pulled into the CUDA translation units via the `qt` type, we reimplement
+// the (small) subset of quaternion operations the code uses. The same type is
+// used by host and device translation units so there is no ABI mismatch.
+// Component order and operation order match boost::math::quaternion.
+struct qt {
+    fl a, b, c, d;
+    qt() : a(0), b(0), c(0), d(0) {}
+    qt(fl a_, fl b_, fl c_, fl d_) : a(a_), b(b_), c(c_), d(d_) {}
+    fl R_component_1() const { return a; }
+    fl R_component_2() const { return b; }
+    fl R_component_3() const { return c; }
+    fl R_component_4() const { return d; }
+    qt& operator*=(fl rhs) {
+        a *= rhs;
+        b *= rhs;
+        c *= rhs;
+        d *= rhs;
+        return *this;
+    }
+    qt& operator/=(fl rhs) {
+        a /= rhs;
+        b /= rhs;
+        c /= rhs;
+        d /= rhs;
+        return *this;
+    }
+    qt& operator*=(const qt& rhs) {  // Hamilton product (matches boost::math::quaternion)
+        const fl ar = rhs.a, br = rhs.b, cr = rhs.c, dr = rhs.d;
+        const qt result(a * ar - b * br - c * cr - d * dr, a * br + b * ar + c * dr - d * cr,
+                        a * cr - b * dr + c * ar + d * br, a * dr + b * cr - c * br + d * ar);
+        *this = result;
+        return *this;
+    }
+    qt& operator/=(const qt& rhs) {  // *this * conj(rhs) / norm_sqr(rhs)
+        const fl nrm2 = rhs.a * rhs.a + rhs.b * rhs.b + rhs.c * rhs.c + rhs.d * rhs.d;
+        const qt conj(rhs.a, -rhs.b, -rhs.c, -rhs.d);
+        *this *= conj;
+        *this /= nrm2;
+        return *this;
+    }
+};
+inline qt operator*(const qt& lhs, const qt& rhs) {
+    qt result(lhs);
+    result *= rhs;
+    return result;
+}
+inline qt operator*(fl lhs, const qt& rhs) {
+    return qt(lhs * rhs.R_component_1(), lhs * rhs.R_component_2(), lhs * rhs.R_component_3(),
+              lhs * rhs.R_component_4());
+}
+inline qt operator*(const qt& lhs, fl rhs) { return rhs * lhs; }
+// Magnitude, equivalent to the former boost::math::abs(q) (scaled for overflow safety).
+inline fl quaternion_norm(const qt& q) {
+    const fl maxim
+        = (std::max)((std::max)(std::abs(q.R_component_1()), std::abs(q.R_component_2())),
+                     (std::max)(std::abs(q.R_component_3()), std::abs(q.R_component_4())));
+    if (maxim == static_cast<fl>(0)) return maxim;
+    const fl mixam = static_cast<fl>(1) / maxim;
+    fl a = q.R_component_1() * mixam;
+    fl b = q.R_component_2() * mixam;
+    fl c = q.R_component_3() * mixam;
+    fl d = q.R_component_4() * mixam;
+    a *= a;
+    b *= b;
+    c *= c;
+    d *= d;
+    return maxim * std::sqrt(a + b + c + d);
+}
 
 // non-intrusive free function split serialization
 namespace boost {
@@ -74,7 +145,7 @@ inline fl quaternion_norm_sqr(const qt& q) {  // equivalent to sqr(boost::math::
 
 inline void quaternion_normalize(qt& q) {
     const fl s = quaternion_norm_sqr(q);
-    assert(eq(s, sqr(boost::math::abs(q))));
+    assert(eq(s, sqr(quaternion_norm(q))));
     const fl a = std::sqrt(s);
     assert(a > epsilon_fl);
     q *= 1 / a;
@@ -83,7 +154,7 @@ inline void quaternion_normalize(qt& q) {
 
 inline void quaternion_normalize_approx(qt& q, const fl tolerance = 1e-6) {
     const fl s = quaternion_norm_sqr(q);
-    assert(eq(s, sqr(boost::math::abs(q))));
+    assert(eq(s, sqr(quaternion_norm(q))));
     if (std::abs(s - 1) < tolerance)
         ;  // most likely scenario
     else {

--- a/unidock/src/lib/random.h
+++ b/unidock/src/lib/random.h
@@ -24,7 +24,15 @@
 #define VINA_RANDOM_H
 
 #include <random>
+#ifdef __CUDACC__
+// nvcc cannot compile Boost.Math's GPU-enabled headers (Boost >= 1.87), which
+// the <boost/random.hpp> umbrella pulls in via its distributions. The CUDA
+// translation units only need the mt19937 engine type, so include just that.
+// Host translation units keep the full umbrella below (unchanged behavior).
+#include <boost/random/mersenne_twister.hpp>
+#else
 #include <boost/random.hpp>
+#endif
 #include "common.h"
 
 typedef boost::mt19937 rng;


### PR DESCRIPTION
## Problem

Building the GPU engine against **Boost ≥ 1.87** fails under `nvcc`:

```
boost/math/tools/numeric_limits.hpp(45): error: "constexpr" is not valid here
                                              error: duplicate specifier in declaration
   ... BOOST_MATH_STATIC constexpr bool is_specialized ...   // expands to `constexpr constexpr`
```

Boost ≥ 1.87 ships GPU-enabled Boost.Math headers. Under `__CUDACC__`, `BOOST_MATH_STATIC` is defined as `constexpr`, and `numeric_limits.hpp` then writes `BOOST_MATH_STATIC constexpr …`, i.e. `constexpr constexpr`, which `nvcc` rejects. The header is pulled into the CUDA TUs (`monte_carlo.cu`, `precalculate.cu`) because `qt = boost::math::quaternion<fl>` is referenced via `conf.h`/`tree.h`.

This is invisible with the bundled Boost (1.84, via `FETCH_BOOST`) and older system Boost (≤ 1.83), but breaks on **conda-forge** (Boost 1.88, migrating to 1.90) — see conda-forge/unidock-feedstock#14, #13, #12. (No clean Boost-side workaround exists: the defect persists through 1.90, the gate is purely `__CUDACC__`, and `-DBOOST_MATH_HAS_NVRTC` / skipping the header / C++17 all fail.)

## Fix

Replace `boost::math::quaternion<fl>` with a small in-tree `qt` type implementing exactly the operations the code uses (construction, `R_component_*`, scalar & Hamilton `*`/`*=`, `/=`, and magnitude), and replace the `boost::math::abs(q)` calls with a `quaternion_norm(q)` helper. The Hamilton product mirrors Boost's expression order.

- **Single type for host and device** (not an `#ifdef` dual type), so there is no ABI/triviality mismatch in shared structs (`conf`, `output_type`).
- `random.h`'s `<boost/random.hpp>` umbrella (which also drags in Boost.Math via its distributions) is narrowed to `<boost/random/mersenne_twister.hpp>` **for `nvcc` only**; host TUs keep the umbrella.

3 files: `quaternion.h`, `quaternion.cpp`, `random.h`.

## Verification (B200, CUDA 12.9, Boost 1.88)

- Both CUDA TUs compile against Boost 1.88 (Release + Debug).
- Docking 100 mmp13 ligands ×3 runs: **no crashes**; affinity distribution matches the Boost build within run-to-run variance:

| build | mean | median | min |
|---|---|---|---|
| Boost `boost::math::quaternion` | −7.01 / −7.03 / −7.04 | ~−7.4 to −7.5 | ~−11.1 |
| custom `qt` | −7.03 / −6.99 / −7.13 | ~−7.43 to −7.49 | ~−11.1 |

(Uni-Dock GPU docking is nondeterministic run-to-run, so equivalence is statistical, not bit-identical.)

Unblocks the conda-forge 1.2.0 / Boost-1.90 / CUDA-13 rebuilds.
