### PR TITLE
unidock_tools: widen requires-python to >=3.10 (support Python 3.13/3.14)

### DIFF
--- a/unidock_tools/pyproject.toml
+++ b/unidock_tools/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "Several docking-related applications based on Uni-Dock."
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 dependencies = [
     "rdkit",
     "networkx",


### PR DESCRIPTION
The `requires-python = ">=3.10,<3.13"` cap blocks installing `unidock_tools` on Python 3.13/3.14, which broke the conda-forge build (it builds variants for those interpreters).

Verified on conda-forge for **both 3.13 and 3.14**: dependency solve, `pip install`, and `unidocktools --help` all succeed. The cap was conservative; dropping the upper bound lets the package build for current interpreters.

Pairs with the conda-forge feedstock PR that builds py3.13/3.14 (previously skipped).