### PR TITLE
build: select C++ standard and GPU arch list by CUDA version (enable CUDA 13)

### DIFF
--- a/unidock/CMakeLists.txt
+++ b/unidock/CMakeLists.txt
@@ -14,7 +14,13 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # >>>>>> Language Configuration Begin
-set(CMAKE_CXX_STANDARD 14)
+# CUDA 13's bundled CCCL / libcu++ requires C++17; CUDA 12.x keeps C++14.
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD 17)
+else()
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 set(CMAKE_CUDA_FLAGS_DEBUG "-g -G")
 option(Boost_USE_STATIC_LIBS "Whether to use static libs for boost" OFF)
@@ -25,7 +31,6 @@ check_language(CUDA)
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
   # https://en.wikipedia.org/wiki/CUDA#GPUs_supported
   set(CMAKE_CUDA_ARCHITECTURES
-    70 # V100
     75 # RTX 20, T4
     80 # A100, A800
     86 # RTX 30
@@ -34,6 +39,10 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     100 # B100, B200, GB200
     120 # RTX 50, B40
   )
+  # CUDA 13 removed Volta (sm_70 / V100); only target it on CUDA 12.x.
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0)
+    list(PREPEND CMAKE_CUDA_ARCHITECTURES 70) # V100
+  endif()
 endif()
 
 # Add fast math for release build


### PR DESCRIPTION
## What

Make `CMAKE_CXX_STANDARD` / `CMAKE_CUDA_STANDARD` and the default GPU architecture list depend on `CMAKE_CUDA_COMPILER_VERSION`, so the same tree builds on both CUDA 12.x and CUDA 13.x.

| | CUDA 12.x | CUDA ≥ 13 |
|---|---|---|
| C++ standard | C++14 | **C++17** (`CMAKE_CXX_STANDARD` + `CMAKE_CUDA_STANDARD`) |
| arch list | `70`(V100) … 120 | **drops `70`** → 75/80/86/89/90/100/120 |

## Why

CUDA 13 can't build the current settings:
- it **removed Volta `sm_70`/V100** → `nvcc fatal: unsupported gpu architecture 'compute_70'`;
- its bundled **CCCL/libcu++ requires C++17** → `libcu++ requires at least C++ 17` against the current `CMAKE_CXX_STANDARD 14`.

CUDA 12.x behaviour is unchanged (C++14, sm_70 retained).

## Verified (B200)

Built clean with the conditional CMakeLists on:
- **CUDA 12.9.2** — C++14, arch list incl. `sm_70`. ✅
- **CUDA 13.2** — C++17, no `sm_70`. ✅

(Any 13.x takes the same branch; the `>= 13.0` gate is what matters.)

## Caveats (documented, not blockers)

- **CUDA 13 drops V100** and measured **~13% slower** than 12.9 on a B200 docking benchmark — so **12.9 stays the recommended default**; this PR just makes 13.x *possible*.
- Building any CUDA version against **system Boost ≥ 1.87** still hits a separate Boost.Math/nvcc bug (boostorg/math#1383, fixed upstream by #1384 → Boost 1.92). The shipped Docker bases (ubuntu22.04/24.04 → Boost 1.74/1.83) are unaffected.
